### PR TITLE
Refactor heat slider into reusable module

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,7 @@
         <div class="header">
             <h1>Design Prototypes</h1>
             <p>Interactive component explorations and experiments</p>
+            <p id="lastUpdated" style="color: #666; font-size: 0.9rem; margin-top: 0.75rem;"></p>
         </div>
 
         <div class="prototypes-grid" id="prototypesGrid">
@@ -193,8 +194,11 @@
     </div>
 
     <script>
-        // Auto-update last updated date
-        document.getElementById('lastUpdated').textContent = new Date().toLocaleDateString();
+        const lastUpdatedEl = document.getElementById('lastUpdated');
+        if (lastUpdatedEl) {
+            const lastModified = new Date(document.lastModified);
+            lastUpdatedEl.textContent = `Last updated ${lastModified.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })}`;
+        }
 
         // You can add auto-discovery of prototypes here later
         // by reading the prototypes directory structure

--- a/prototypes/custom-cook/heat-slider-example.html
+++ b/prototypes/custom-cook/heat-slider-example.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Custom Cook with Heat Slider</title>
 
-  <!-- Include shared heat slider component styles -->
+  <!-- Include shared design tokens and heat slider component styles -->
+  <link rel="stylesheet" href="../../shared/tokens.css">
   <link rel="stylesheet" href="../../shared/components/heat-slider.css">
 
   <style>
@@ -13,9 +14,9 @@
 
     body {
       margin: 0;
-      background: var(--bg);
-      color: #eee;
-      font-family: Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+      background: var(--color-bg-default);
+      color: var(--color-text-primary);
+      font-family: var(--font-sans);
       display: grid;
       place-items: center;
       min-height: 100vh;
@@ -24,10 +25,10 @@
 
     .cook-container {
       width: 400px;
-      background: #1a1a1a;
+      background: var(--color-surface);
       border-radius: 16px;
       padding: 24px;
-      border: 1px solid #333;
+      border: 1px solid rgba(255, 255, 255, 0.08);
     }
 
     .cook-header {
@@ -43,7 +44,7 @@
 
     .cook-subtitle {
       font-size: 14px;
-      color: #888;
+      color: var(--color-text-muted);
       margin: 0;
     }
 
@@ -55,11 +56,11 @@
       font-size: 16px;
       font-weight: 600;
       margin: 0 0 16px 0;
-      color: #fff;
+      color: var(--color-text-primary);
     }
 
     .temp-display {
-      background: #2a2a2a;
+      background: rgba(255, 255, 255, 0.06);
       border-radius: 12px;
       padding: 16px;
       text-align: center;
@@ -69,27 +70,27 @@
     .temp-value {
       font-size: 32px;
       font-weight: 700;
-      color: #ff5f42;
+      color: var(--color-accent);
       margin: 0;
     }
 
     .temp-unit {
       font-size: 14px;
-      color: #888;
+      color: var(--color-text-muted);
     }
 
     .instructions {
-      background: #2a2a2a;
+      background: rgba(255, 255, 255, 0.04);
       border-radius: 8px;
       padding: 12px;
       font-size: 12px;
-      color: #aaa;
+      color: var(--color-text-muted);
       margin-top: 16px;
     }
 
     /* Custom styling for the heat slider in this context */
     #heatSliderContainer {
-      background: #2a2a2a;
+      background: rgba(255, 255, 255, 0.04);
       border-radius: 12px;
       padding: 16px;
     }
@@ -122,20 +123,18 @@
     </div>
   </div>
 
-  <!-- Include shared heat slider component script -->
-  <script src="../../shared/components/heat-slider.js"></script>
+  <script type="module">
+    import { createHeatSlider } from '../../shared/components/heat-slider.js';
 
-  <script>
-    // Initialize the heat slider component
-    const heatSlider = HeatSlider.create('heatSliderContainer', {
+    const heatSlider = createHeatSlider('heatSliderContainer', {
       initialPosition: 60,
       showLabel: true,
       stepMode: 'preset',
-      onChange: function(data) {
+      onChange(data) {
         console.log('Heat distribution changed:', data);
         // You could update other UI elements here based on the heat distribution
       },
-      onToggle: function(data) {
+      onToggle(data) {
         console.log('Heat slider toggled:', data);
         // Handle on/off state changes
       }

--- a/shared/components/heat-slider.css
+++ b/shared/components/heat-slider.css
@@ -1,15 +1,19 @@
 /* Heat Slider Component Styles */
-:root {
-  --bg: #0b0b0b;
-  --cool: #490307;
-  --hot-r: 255;
-  --hot-g: 95;
-  --hot-b: 66;
-  --hot: rgb(var(--hot-r), var(--hot-g), var(--hot-b));
-  --p: 50; /* peak position 0-100 (Top %) */
-  --w: 40; /* half-width of hot band */
-  --intensity: 0.85; /* editable by debug UI */
-  --anim-ms: 80ms; /* editable by debug UI */
+@import url('../tokens.css');
+
+.heat-slider {
+  --heat-slider-cool: var(--heat-cool, #490307);
+  --heat-slider-hot-r: var(--heat-hot-r, 255);
+  --heat-slider-hot-g: var(--heat-hot-g, 95);
+  --heat-slider-hot-b: var(--heat-hot-b, 66);
+  --heat-slider-intensity: var(--heat-intensity, 0.85);
+  --heat-slider-anim: var(--heat-animation-ms, 80ms);
+  --heat-slider-peak: 50;
+  --heat-slider-width: 40;
+  font-family: var(--font-sans, 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+  color: var(--color-text-primary, #eee);
+  display: grid;
+  gap: 8px;
 }
 
 .heat-slider-row {
@@ -24,10 +28,10 @@
 .heat-slider-heatbar {
   position: relative;
   height: 32px;
-  border-radius: 16px;
-  background: var(--cool);
+  border-radius: var(--radius-pill, 16px);
+  background: var(--heat-slider-cool);
   overflow: hidden;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  box-shadow: var(--shadow-inset-subtle, inset 0 0 0 1px rgba(255, 255, 255, 0.05));
   width: 100%;
   min-width: 0;
   transition: height 0.3s ease;
@@ -40,19 +44,30 @@
   border-radius: inherit;
   background: linear-gradient(
     to right,
-    rgba(var(--hot-r), var(--hot-g), var(--hot-b), 0) calc(var(--p) * 1% - calc(var(--w) * 1.5%)),
-    rgba(var(--hot-r), var(--hot-g), var(--hot-b), 0.1) calc(var(--p) * 1% - calc(var(--w) * 1.2%)),
-    rgba(var(--hot-r), var(--hot-g), var(--hot-b), 0.3) calc(var(--p) * 1% - calc(var(--w) * 0.8%)),
-    rgba(var(--hot-r), var(--hot-g), var(--hot-b), 0.6) calc(var(--p) * 1% - calc(var(--w) * 0.4%)),
-    rgba(var(--hot-r), var(--hot-g), var(--hot-b), var(--intensity)) calc(var(--p) * 1% - calc(var(--w) * 0.1%)),
-    rgba(var(--hot-r), var(--hot-g), var(--hot-b), 1) calc(var(--p) * 1%),
-    rgba(var(--hot-r), var(--hot-g), var(--hot-b), var(--intensity)) calc(var(--p) * 1% + calc(var(--w) * 0.1%)),
-    rgba(var(--hot-r), var(--hot-g), var(--hot-b), 0.6) calc(var(--p) * 1% + calc(var(--w) * 0.4%)),
-    rgba(var(--hot-r), var(--hot-g), var(--hot-b), 0.3) calc(var(--p) * 1% + calc(var(--w) * 0.8%)),
-    rgba(var(--hot-r), var(--hot-g), var(--hot-b), 0.1) calc(var(--p) * 1% + calc(var(--w) * 1.2%)),
-    rgba(var(--hot-r), var(--hot-g), var(--hot-b), 0) calc(var(--p) * 1% + calc(var(--w) * 1.5%))
+    rgba(var(--heat-slider-hot-r), var(--heat-slider-hot-g), var(--heat-slider-hot-b), 0)
+      calc(var(--heat-slider-peak) * 1% - calc(var(--heat-slider-width) * 1.5%)),
+    rgba(var(--heat-slider-hot-r), var(--heat-slider-hot-g), var(--heat-slider-hot-b), 0.1)
+      calc(var(--heat-slider-peak) * 1% - calc(var(--heat-slider-width) * 1.2%)),
+    rgba(var(--heat-slider-hot-r), var(--heat-slider-hot-g), var(--heat-slider-hot-b), 0.3)
+      calc(var(--heat-slider-peak) * 1% - calc(var(--heat-slider-width) * 0.8%)),
+    rgba(var(--heat-slider-hot-r), var(--heat-slider-hot-g), var(--heat-slider-hot-b), 0.6)
+      calc(var(--heat-slider-peak) * 1% - calc(var(--heat-slider-width) * 0.4%)),
+    rgba(var(--heat-slider-hot-r), var(--heat-slider-hot-g), var(--heat-slider-hot-b), var(--heat-slider-intensity))
+      calc(var(--heat-slider-peak) * 1% - calc(var(--heat-slider-width) * 0.1%)),
+    rgba(var(--heat-slider-hot-r), var(--heat-slider-hot-g), var(--heat-slider-hot-b), 1)
+      calc(var(--heat-slider-peak) * 1%),
+    rgba(var(--heat-slider-hot-r), var(--heat-slider-hot-g), var(--heat-slider-hot-b), var(--heat-slider-intensity))
+      calc(var(--heat-slider-peak) * 1% + calc(var(--heat-slider-width) * 0.1%)),
+    rgba(var(--heat-slider-hot-r), var(--heat-slider-hot-g), var(--heat-slider-hot-b), 0.6)
+      calc(var(--heat-slider-peak) * 1% + calc(var(--heat-slider-width) * 0.4%)),
+    rgba(var(--heat-slider-hot-r), var(--heat-slider-hot-g), var(--heat-slider-hot-b), 0.3)
+      calc(var(--heat-slider-peak) * 1% + calc(var(--heat-slider-width) * 0.8%)),
+    rgba(var(--heat-slider-hot-r), var(--heat-slider-hot-g), var(--heat-slider-hot-b), 0.1)
+      calc(var(--heat-slider-peak) * 1% + calc(var(--heat-slider-width) * 1.2%)),
+    rgba(var(--heat-slider-hot-r), var(--heat-slider-hot-g), var(--heat-slider-hot-b), 0)
+      calc(var(--heat-slider-peak) * 1% + calc(var(--heat-slider-width) * 1.5%))
   );
-  transition: background-position var(--anim-ms) linear, background var(--anim-ms) linear;
+  transition: background-position var(--heat-slider-anim) linear, background var(--heat-slider-anim) linear;
 }
 
 /* Split indicator — clamped to stay within bounds with padding */
@@ -60,29 +75,29 @@
   content: "";
   position: absolute;
   /* Keep the indicator inside the pill with 24px padding from edges */
-  left: calc(24px + (var(--p) * 1% * (100% - 48px) / 100%) - 2px);
+  left: calc(24px + (var(--heat-slider-peak) * 1% * (100% - 48px) / 100%) - 2px);
   top: 2px;
   bottom: 2px;
   width: 4px;
   background: #fff;
-  border-radius: 2px;
+  border-radius: var(--radius-indicator, 2px);
   opacity: 0.9;
   pointer-events: none;
 }
 
 /* Off state - greyscale only the background and overlay */
-body.off .heat-slider-heatbar {
+.heat-slider.is-off .heat-slider-heatbar {
   background: #33333342;
   height: 24px;
   transition: height 0.3s ease;
 }
 
-body.off .heat-slider-heatbar .overlay {
+.heat-slider.is-off .heat-slider-heatbar .overlay {
   filter: grayscale(100%);
 }
 
-body.off .heat-slider-heatbar::after {
-  background: #fa4947;
+.heat-slider.is-off .heat-slider-heatbar::after {
+  background: var(--color-accent, #fa4947);
 }
 
 .heat-slider-icon {
@@ -99,7 +114,7 @@ body.off .heat-slider-heatbar::after {
   text-align: center;
   font-weight: 600;
   font-size: 16px;
-  color: #eee;
+  color: var(--color-text-primary, #eee);
   margin-top: 8px;
   font-variant-numeric: tabular-nums;
 }
@@ -109,5 +124,7 @@ body.off .heat-slider-heatbar::after {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  :root { --anim-ms: 0ms; }
+  .heat-slider {
+    --heat-slider-anim: 0ms;
+  }
 }

--- a/shared/components/heat-slider.js
+++ b/shared/components/heat-slider.js
@@ -1,203 +1,216 @@
 /**
  * Heat Slider Component
- * Provides oven heat distribution visualization with interactive controls
+ * Provides oven heat distribution visualization with interactive controls.
  *
  * Usage:
- * 1. Include heat-slider.css in your HTML
- * 2. Include this script
- * 3. Call HeatSlider.init() with your container element
+ * 1. Include shared/tokens.css (optional but recommended) and this stylesheet.
+ * 2. Import the module: `import { createHeatSlider } from '../../shared/components/heat-slider.js';`
+ * 3. Call `createHeatSlider(container, options)` with an element or element id.
  */
 
-window.HeatSlider = (function() {
-  'use strict';
+const clampPercentage = (value) => Math.max(0, Math.min(100, Math.round(Number(value) || 0)));
 
-  const clamp01 = (v) => Math.max(0, Math.min(100, Math.round(Number(v) || 0)));
+const resolveContainer = (containerOrId) => {
+  if (typeof containerOrId === 'string') {
+    return document.getElementById(containerOrId);
+  }
+  return containerOrId;
+};
 
-  function createHeatSlider(containerId, options = {}) {
-    const container = document.getElementById(containerId);
-    if (!container) {
-      console.error(`Heat slider container with id "${containerId}" not found`);
-      return null;
-    }
+const defaultKeyboardMap = { left: 'o', right: 'p', reset: 'r', toggle: 'q' };
 
-    // Default options
-    const config = {
-      initialPosition: 50,
-      showLabel: false,
-      enableKeyboard: true,
-      keyboardKeys: { left: 'o', right: 'p', reset: 'r', toggle: 'q' },
-      stepMode: 'preset', // 'preset', '1', '5', '20'
-      ...options
-    };
-
-    // Create HTML structure
-    container.innerHTML = `
-      <div class="heat-slider-row" aria-label="Heat distribution" role="group">
-        <div class="heat-slider-icon heat-slider-icon-bottom" aria-label="Bottom element" role="img">
-          <svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg" style="transform: rotate(180deg);">
-            <path d="M21.6667 13.25C22.219 13.25 22.6667 13.6977 22.6667 14.25V18C22.6667 20.2091 20.8759 22 18.6667 22H6.66675C4.45761 22 2.66675 20.2091 2.66675 18V14.25C2.66675 13.6977 3.11446 13.25 3.66675 13.25C4.21903 13.25 4.66675 13.6977 4.66675 14.25V18C4.66675 19.1046 5.56218 20 6.66675 20H18.6667C19.7713 20 20.6667 19.1046 20.6667 18V14.25C20.6667 13.6977 21.1145 13.25 21.6667 13.25ZM18.6667 2C20.8759 2 22.6667 3.79086 22.6667 6V9.75C22.6667 10.3023 22.219 10.75 21.6667 10.75C21.1145 10.75 20.6667 10.3023 20.6667 9.75V6C20.6667 4.89543 19.7713 4 18.6667 4H6.66675C5.56218 4 4.66675 4.89543 4.66675 6V9.75C4.66675 10.3023 4.21903 10.75 3.66675 10.75C3.11446 10.75 2.66675 10.3023 2.66675 9.75V6C2.66675 3.79086 4.45761 2 6.66675 2H18.6667ZM16.7244 6C17.1213 6.00004 17.3933 6.207 17.53 6.34668L17.533 6.34961L19.3845 8.25684C19.7692 8.65308 19.7593 9.2862 19.363 9.6709C18.9668 10.0555 18.3337 10.0466 17.949 9.65039L16.7244 8.38867L15.4988 9.65039L15.4968 9.65332C15.3602 9.79299 15.0881 9.99993 14.6912 10C14.2943 9.99999 14.0222 9.79301 13.8855 9.65332L13.8826 9.65039L12.6501 8.37988L11.5291 9.50391C11.4847 9.57969 11.4308 9.65153 11.365 9.71582C10.9698 10.1013 10.3367 10.0932 9.95093 9.69824L8.66675 8.38281L7.38257 9.69824C6.99685 10.0933 6.36368 10.1013 5.96851 9.71582C5.57348 9.3301 5.56545 8.69693 5.95093 8.30176L7.85815 6.34863L7.86011 6.3457L7.98901 6.23242C8.14242 6.11535 8.3699 6 8.66675 6C9.06261 6.00001 9.33513 6.2052 9.47339 6.3457L9.47534 6.34863L10.6511 7.55273L11.8582 6.34082L11.8591 6.3418C11.9977 6.20225 12.2667 6.00001 12.658 6C13.0549 6.0001 13.327 6.20702 13.4636 6.34668L13.4656 6.34961L14.6912 7.61035L15.9158 6.34961L15.9187 6.34668L16.0466 6.23438C16.1993 6.11711 16.4265 6.00001 16.7244 6Z" fill="white"/>
-          </svg>
-        </div>
-
-        <div class="heat-slider-heatbar" aria-hidden="true">
-          <div class="overlay"></div>
-        </div>
-
-        <div class="heat-slider-icon heat-slider-icon-top" aria-label="Top element" role="img">
-          <svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M21.6667 13.25C22.219 13.25 22.6667 13.6977 22.6667 14.25V18C22.6667 20.2091 20.8759 22 18.6667 22H6.66675C4.45761 22 2.66675 20.2091 2.66675 18V14.25C2.66675 13.6977 3.11446 13.25 3.66675 13.25C4.21903 13.25 4.66675 13.6977 4.66675 14.25V18C4.66675 19.1046 5.56218 20 6.66675 20H18.6667C19.7713 20 20.6667 19.1046 20.6667 18V14.25C20.6667 13.6977 21.1145 13.25 21.6667 13.25ZM18.6667 2C20.8759 2 22.6667 3.79086 22.6667 6V9.75C22.6667 10.3023 22.219 10.75 21.6667 10.75C21.1145 10.75 20.6667 10.3023 20.6667 9.75V6C20.6667 4.89543 19.7713 4 18.6667 4H6.66675C5.56218 4 4.66675 4.89543 4.66675 6V9.75C4.66675 10.3023 4.21903 10.75 3.66675 10.75C3.11446 10.75 2.66675 10.3023 2.66675 9.75V6C2.66675 3.79086 4.45761 2 6.66675 2H18.6667ZM16.7244 6C17.1213 6.00004 17.3933 6.207 17.53 6.34668L17.533 6.34961L19.3845 8.25684C19.7692 8.65308 19.7593 9.2862 19.363 9.6709C18.9668 10.0555 18.3337 10.0466 17.949 9.65039L16.7244 8.38867L15.4988 9.65039L15.4968 9.65332C15.3602 9.79299 15.0881 9.99993 14.6912 10C14.2943 9.99999 14.0222 9.79301 13.8855 9.65332L13.8826 9.65039L12.6501 8.37988L11.5291 9.50391C11.4847 9.57969 11.4308 9.65153 11.365 9.71582C10.9698 10.1013 10.3367 10.0932 9.95093 9.69824L8.66675 8.38281L7.38257 9.69824C6.99685 10.0933 6.36368 10.1013 5.96851 9.71582C5.57348 9.3301 5.56545 8.69693 5.95093 8.30176L7.85815 6.34863L7.86011 6.3457L7.98901 6.23242C8.14242 6.11535 8.3699 6 8.66675 6C9.06261 6.00001 9.33513 6.2052 9.47339 6.3457L9.47534 6.34863L10.6511 7.55273L11.8582 6.34082L11.8591 6.3418C11.9977 6.20225 12.2667 6.00001 12.658 6C13.0549 6.0001 13.327 6.20702 13.4636 6.34668L13.4656 6.34961L14.6912 7.61035L15.9158 6.34961L15.9187 6.34668L16.0466 6.23438C16.1993 6.11711 16.4265 6.00001 16.7244 6Z" fill="white"/>
-          </svg>
-        </div>
+function buildMarkup({ showLabel }) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'heat-slider';
+  wrapper.innerHTML = `
+    <div class="heat-slider-row" aria-label="Heat distribution" role="group">
+      <div class="heat-slider-icon heat-slider-icon-bottom" aria-label="Bottom element" role="img">
+        <svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg" style="transform: rotate(180deg);">
+          <path d="M21.6667 13.25C22.219 13.25 22.6667 13.6977 22.6667 14.25V18C22.6667 20.2091 20.8759 22 18.6667 22H6.66675C4.45761 22 2.66675 20.2091 2.66675 18V14.25C2.66675 13.6977 3.11446 13.25 3.66675 13.25C4.21903 13.25 4.66675 13.6977 4.66675 14.25V18C4.66675 19.1046 5.56218 20 6.66675 20H18.6667C19.7713 20 20.6667 19.1046 20.6667 18V14.25C20.6667 13.6977 21.1145 13.25 21.6667 13.25ZM18.6667 2C20.8759 2 22.6667 3.79086 22.6667 6V9.75C22.6667 10.3023 22.219 10.75 21.6667 10.75C21.1145 10.75 20.6667 10.3023 20.6667 9.75V6C20.6667 4.89543 19.7713 4 18.6667 4H6.66675C5.56218 4 4.66675 4.89543 4.66675 6V9.75C4.66675 10.3023 4.21903 10.75 3.66675 10.75C3.11446 10.75 2.66675 10.3023 2.66675 9.75V6C2.66675 3.79086 4.45761 2 6.66675 2H18.6667ZM16.7244 6C17.1213 6.00004 17.3933 6.207 17.53 6.34668L17.533 6.34961L19.3845 8.25684C19.7692 8.65308 19.7593 9.2862 19.363 9.6709C18.9668 10.0555 18.3337 10.0466 17.949 9.65039L16.7244 8.38867L15.4988 9.65039L15.4968 9.65332C15.3602 9.79299 15.0881 9.99993 14.6912 10C14.2943 9.99999 14.0222 9.79301 13.8855 9.65332L13.8826 9.65039L12.6501 8.37988L11.5291 9.50391C11.4847 9.57969 11.4308 9.65153 11.365 9.71582C10.9698 10.1013 10.3367 10.0932 9.95093 9.69824L8.66675 8.38281L7.38257 9.69824C6.99685 10.0933 6.36368 10.1013 5.96851 9.71582C5.57348 9.3301 5.56545 8.69693 5.95093 8.30176L7.85815 6.34863L7.86011 6.3457L7.98901 6.23242C8.14242 6.11535 8.3699 6 8.66675 6C9.06261 6.00001 9.33513 6.2052 9.47339 6.3457L9.47534 6.34863L10.6511 7.55273L11.8582 6.34082L11.8591 6.3418C11.9977 6.20225 12.2667 6.00001 12.658 6C13.0549 6.0001 13.327 6.20702 13.4636 6.34668L13.4656 6.34961L14.6912 7.61035L15.9158 6.34961L15.9187 6.34668L16.0466 6.23438C16.1993 6.11711 16.4265 6.00001 16.7244 6Z" fill="white"/>
+        </svg>
       </div>
 
-      <div class="heat-slider-distribution-label${config.showLabel ? '' : ' hidden'}" aria-live="polite"></div>
-    `;
+      <div class="heat-slider-heatbar" aria-hidden="true">
+        <div class="overlay"></div>
+      </div>
 
-    // Get elements
-    const root = document.documentElement;
-    const iconTop = container.querySelector('.heat-slider-icon-top');
-    const iconBottom = container.querySelector('.heat-slider-icon-bottom');
-    const distributionLabel = container.querySelector('.heat-slider-distribution-label');
+      <div class="heat-slider-icon heat-slider-icon-top" aria-label="Top element" role="img">
+        <svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M21.6667 13.25C22.219 13.25 22.6667 13.6977 22.6667 14.25V18C22.6667 20.2091 20.8759 22 18.6667 22H6.66675C4.45761 22 2.66675 20.2091 2.66675 18V14.25C2.66675 13.6977 3.11446 13.25 3.66675 13.25C4.21903 13.25 4.66675 13.6977 4.66675 14.25V18C4.66675 19.1046 5.56218 20 6.66675 20H18.6667C19.7713 20 20.6667 19.1046 20.6667 18V14.25C20.6667 13.6977 21.1145 13.25 21.6667 13.25ZM18.6667 2C20.8759 2 22.6667 3.79086 22.6667 6V9.75C22.6667 10.3023 22.219 10.75 21.6667 10.75C21.1145 10.75 20.6667 10.3023 20.6667 9.75V6C20.6667 4.89543 19.7713 4 18.6667 4H6.66675C5.56218 4 4.66675 4.89543 4.66675 6V9.75C4.66675 10.3023 4.21903 10.75 3.66675 10.75C3.11446 10.75 2.66675 10.3023 2.66675 9.75V6C2.66675 3.79086 4.45761 2 6.66675 2H18.6667ZM16.7244 6C17.1213 6.00004 17.3933 6.207 17.53 6.34668L17.533 6.34961L19.3845 8.25684C19.7692 8.65308 19.7593 9.2862 19.363 9.6709C18.9668 10.0555 18.3337 10.0466 17.949 9.65039L16.7244 8.38867L15.4988 9.65039L15.4968 9.65332C15.3602 9.79299 15.0881 9.99993 14.6912 10C14.2943 9.99999 14.0222 9.79301 13.8855 9.65332L13.8826 9.65039L12.6501 8.37988L11.5291 9.50391C11.4847 9.57969 11.4308 9.65153 11.365 9.71582C10.9698 10.1013 10.3367 10.0932 9.95093 9.69824L8.66675 8.38281L7.38257 9.69824C6.99685 10.0933 6.36368 10.1013 5.96851 9.71582C5.57348 9.3301 5.56545 8.69693 5.95093 8.30176L7.85815 6.34863L7.86011 6.3457L7.98901 6.23242C8.14242 6.11535 8.3699 6 8.66675 6C9.06261 6.00001 9.33513 6.2052 9.47339 6.3457L9.47534 6.34863L10.6511 7.55273L11.8582 6.34082L11.8591 6.3418C11.9977 6.20225 12.2667 6.00001 12.658 6C13.0549 6.0001 13.327 6.20702 13.4636 6.34668L13.4656 6.34961L14.6912 7.61035L15.9158 6.34961L15.9187 6.34668L16.0466 6.23438C16.1993 6.11711 16.4265 6.00001 16.7244 6Z" fill="white"/>
+        </svg>
+      </div>
+    </div>
+    <div class="heat-slider-distribution-label${showLabel ? '' : ' hidden'}" aria-live="polite"></div>
+  `;
+  return wrapper;
+}
 
-    let isOn = true;
-    let currentPosition = config.initialPosition;
-
-    const getP = () => {
-      const raw = root.style.getPropertyValue('--p');
-      return raw ? clamp01(raw) : currentPosition;
-    };
-
-    function setTopPct(v) {
-      const topPct = clamp01(v);
-      const bottomPct = 100 - topPct;
-      currentPosition = topPct;
-
-      // Update CSS variable for peak position
-      root.style.setProperty('--p', String(topPct));
-
-      // Calculate dynamic heat band width: 50 at edges, 25 in middle
-      const distanceFromCenter = Math.abs(topPct - 50) / 50;
-      const dynamicWidth = 25 + (distanceFromCenter * 25);
-      root.style.setProperty('--w', String(dynamicWidth));
-
-      // Calculate dynamic icon opacity
-      let leftOpacity, rightOpacity;
-
-      if (topPct <= 50) {
-        const progress = (50 - topPct) / 50;
-        leftOpacity = 0.5 + (progress * 0.5);
-        rightOpacity = 0.5 - (progress * 0.4);
-      } else {
-        const progress = (topPct - 50) / 50;
-        leftOpacity = 0.5 - (progress * 0.4);
-        rightOpacity = 0.5 + (progress * 0.5);
-      }
-
-      iconBottom.style.opacity = leftOpacity.toFixed(2);
-      iconTop.style.opacity = rightOpacity.toFixed(2);
-
-      // Update distribution label
-      if (distributionLabel) {
-        distributionLabel.textContent = `${bottomPct}% Bottom / ${topPct}% Top`;
-      }
-
-      // Trigger callback if provided
-      if (options.onChange) {
-        options.onChange({ topPct, bottomPct, isOn });
-      }
-    }
-
-    function toggleOnOff() {
-      isOn = !isOn;
-      document.body.classList.toggle('off', !isOn);
-
-      if (options.onToggle) {
-        options.onToggle({ isOn, position: currentPosition });
-      }
-    }
-
-    // Keyboard controls
-    if (config.enableKeyboard) {
-      const keyHandler = (e) => {
-        const k = e.key.toLowerCase();
-        if (k === config.keyboardKeys.toggle) {
-          e.preventDefault();
-          toggleOnOff();
-        } else if ((k === config.keyboardKeys.left || k === config.keyboardKeys.right) && isOn) {
-          e.preventDefault();
-          const current = getP();
-
-          if (config.stepMode === 'preset') {
-            const presets = [0, 25, 50, 75, 100];
-            const currentIndex = presets.findIndex(preset => Math.abs(preset - current) <= 2);
-            let newIndex;
-
-            if (currentIndex === -1) {
-              newIndex = k === config.keyboardKeys.left
-                ? presets.findIndex(preset => preset >= current) - 1
-                : presets.findIndex(preset => preset > current);
-            } else {
-              newIndex = currentIndex + (k === config.keyboardKeys.left ? -1 : 1);
-            }
-
-            if (newIndex >= 0 && newIndex < presets.length) {
-              setTopPct(presets[newIndex]);
-            }
-          } else {
-            const stepSize = parseInt(config.stepMode) || 1;
-            const delta = k === config.keyboardKeys.left ? -stepSize : stepSize;
-            setTopPct(current + delta);
-          }
-        } else if (k === config.keyboardKeys.reset) {
-          e.preventDefault();
-          setTopPct(50);
-        }
-      };
-
-      document.addEventListener('keydown', keyHandler);
-
-      // Return cleanup function
-      const cleanup = () => {
-        document.removeEventListener('keydown', keyHandler);
-      };
-
-      // Initialize
-      setTopPct(config.initialPosition);
-
-      return {
-        setPosition: setTopPct,
-        getPosition: () => currentPosition,
-        toggle: toggleOnOff,
-        isOn: () => isOn,
-        cleanup,
-        setStepMode: (mode) => { config.stepMode = mode; },
-        showLabel: (show) => {
-          if (distributionLabel) {
-            distributionLabel.classList.toggle('hidden', !show);
-          }
-        }
-      };
-    }
-
-    // Initialize without keyboard
-    setTopPct(config.initialPosition);
-
-    return {
-      setPosition: setTopPct,
-      getPosition: () => currentPosition,
-      toggle: toggleOnOff,
-      isOn: () => isOn,
-      setStepMode: (mode) => { config.stepMode = mode; },
-      showLabel: (show) => {
-        if (distributionLabel) {
-          distributionLabel.classList.toggle('hidden', !show);
-        }
-      }
-    };
+export function createHeatSlider(containerOrId, options = {}) {
+  const container = resolveContainer(containerOrId);
+  if (!container) {
+    console.error('Heat slider container not found:', containerOrId);
+    return null;
   }
 
-  // Public API
-  return {
-    create: createHeatSlider
+  const config = {
+    initialPosition: 50,
+    showLabel: false,
+    enableKeyboard: true,
+    keyboardTarget: null,
+    keyboardKeys: defaultKeyboardMap,
+    stepMode: 'preset', // 'preset', '1', '5', '20'
+    initiallyOn: true,
+    ...options
   };
-})();
+
+  container.innerHTML = '';
+  const sliderRoot = buildMarkup({ showLabel: config.showLabel });
+  container.appendChild(sliderRoot);
+
+  const iconTop = sliderRoot.querySelector('.heat-slider-icon-top');
+  const iconBottom = sliderRoot.querySelector('.heat-slider-icon-bottom');
+  const distributionLabel = sliderRoot.querySelector('.heat-slider-distribution-label');
+
+  let isOn = Boolean(config.initiallyOn);
+  let currentPosition = config.initialPosition;
+
+  sliderRoot.classList.toggle('is-off', !isOn);
+
+  const setVariables = (topPct) => {
+    const clamped = clampPercentage(topPct);
+    const bottomPct = 100 - clamped;
+    currentPosition = clamped;
+
+    sliderRoot.style.setProperty('--heat-slider-peak', String(clamped));
+
+    const distanceFromCenter = Math.abs(clamped - 50) / 50;
+    const dynamicWidth = 25 + (distanceFromCenter * 25);
+    sliderRoot.style.setProperty('--heat-slider-width', String(dynamicWidth));
+
+    let bottomOpacity;
+    let topOpacity;
+
+    if (clamped <= 50) {
+      const progress = (50 - clamped) / 50;
+      bottomOpacity = 0.5 + (progress * 0.5);
+      topOpacity = 0.5 - (progress * 0.4);
+    } else {
+      const progress = (clamped - 50) / 50;
+      bottomOpacity = 0.5 - (progress * 0.4);
+      topOpacity = 0.5 + (progress * 0.5);
+    }
+
+    iconBottom.style.opacity = bottomOpacity.toFixed(2);
+    iconTop.style.opacity = topOpacity.toFixed(2);
+
+    if (distributionLabel) {
+      distributionLabel.textContent = `${bottomPct}% Bottom / ${clamped}% Top`;
+    }
+
+    if (typeof config.onChange === 'function') {
+      config.onChange({ topPct: clamped, bottomPct, isOn });
+    }
+  };
+
+  const toggleOnOff = () => {
+    isOn = !isOn;
+    sliderRoot.classList.toggle('is-off', !isOn);
+    if (typeof config.onToggle === 'function') {
+      config.onToggle({ isOn, position: currentPosition });
+    }
+  };
+
+  const getCurrentPosition = () => currentPosition;
+
+  const keyHandler = (event) => {
+    if (!config.enableKeyboard) return;
+
+    const key = event.key.toLowerCase();
+    if (key === config.keyboardKeys.toggle) {
+      event.preventDefault();
+      toggleOnOff();
+      return;
+    }
+
+    if (key === config.keyboardKeys.reset) {
+      event.preventDefault();
+      setVariables(50);
+      return;
+    }
+
+    if (!isOn) return;
+
+    if (key === config.keyboardKeys.left || key === config.keyboardKeys.right) {
+      event.preventDefault();
+      const deltaSign = key === config.keyboardKeys.left ? -1 : 1;
+
+      if (config.stepMode === 'preset') {
+        const presets = [0, 25, 50, 75, 100];
+        const currentIndex = presets.findIndex((preset) => Math.abs(preset - getCurrentPosition()) <= 2);
+
+        if (currentIndex === -1) {
+          const lowerPresets = presets.filter((preset) => preset < currentPosition);
+          const higherPresets = presets.filter((preset) => preset > currentPosition);
+          const nextValue = deltaSign === -1 ? lowerPresets.pop() : higherPresets.shift();
+          if (typeof nextValue === 'number') {
+            setVariables(nextValue);
+          }
+          return;
+        }
+
+        const nextIndex = currentIndex + deltaSign;
+        if (nextIndex >= 0 && nextIndex < presets.length) {
+          setVariables(presets[nextIndex]);
+        }
+      } else {
+        const stepSize = parseInt(config.stepMode, 10) || 1;
+        setVariables(getCurrentPosition() + (deltaSign * stepSize));
+      }
+    }
+  };
+
+  const keyboardTarget = config.keyboardTarget || container;
+  if (config.enableKeyboard && keyboardTarget && typeof keyboardTarget.addEventListener === 'function') {
+    keyboardTarget.addEventListener('keydown', keyHandler);
+
+    if (keyboardTarget instanceof HTMLElement || keyboardTarget instanceof SVGElement) {
+      if (!keyboardTarget.hasAttribute('tabindex')) {
+        keyboardTarget.setAttribute('tabindex', '0');
+      }
+      if (!keyboardTarget.getAttribute('role')) {
+        keyboardTarget.setAttribute('role', 'group');
+      }
+      if (!keyboardTarget.getAttribute('aria-label')) {
+        keyboardTarget.setAttribute('aria-label', 'Heat distribution controls');
+      }
+    }
+  } else if (config.enableKeyboard) {
+    console.warn('Heat slider keyboard target does not support events:', keyboardTarget);
+  }
+
+  setVariables(currentPosition);
+
+  return {
+    root: sliderRoot,
+    setPosition: setVariables,
+    getPosition: getCurrentPosition,
+    toggle: toggleOnOff,
+    isOn: () => isOn,
+    cleanup: () => {
+      if (config.enableKeyboard && keyboardTarget && typeof keyboardTarget.removeEventListener === 'function') {
+        keyboardTarget.removeEventListener('keydown', keyHandler);
+      }
+    },
+    setStepMode: (mode) => {
+      config.stepMode = mode;
+    },
+    showLabel: (show) => {
+      if (distributionLabel) {
+        distributionLabel.classList.toggle('hidden', !show);
+      }
+    }
+  };
+}
+
+export const HeatSlider = { create: createHeatSlider };
+export default HeatSlider;

--- a/shared/tokens.css
+++ b/shared/tokens.css
@@ -1,0 +1,29 @@
+/* Shared design tokens for design prototypes */
+:root {
+  /* Typography */
+  --font-sans: 'Inter', 'JaffleNeue', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-sans-strong: 'JaffleNeue', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+  /* Color palette */
+  --color-bg-default: #0b0b0b;
+  --color-surface: #1a1a1a;
+  --color-surface-muted: rgba(255, 255, 255, 0.05);
+  --color-text-primary: #eeeeee;
+  --color-text-muted: #888888;
+  --color-accent: #fa4947;
+
+  /* Heat slider defaults */
+  --heat-cool: #490307;
+  --heat-hot-r: 255;
+  --heat-hot-g: 95;
+  --heat-hot-b: 66;
+  --heat-intensity: 0.85;
+  --heat-animation-ms: 80ms;
+
+  /* Radii */
+  --radius-pill: 16px;
+  --radius-indicator: 2px;
+
+  /* Shadows */
+  --shadow-inset-subtle: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}


### PR DESCRIPTION
## Summary
- convert the shared heat slider into an ES module that renders a scoped wrapper and keeps keyboard handling local
- refresh the component stylesheet to rely on shared design tokens and support scoped CSS variables
- add a tokens stylesheet, update the custom cook example to use the new module API, and show the last updated date on the landing page

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d5749178c0832d8566f7207930d47b